### PR TITLE
when use Layout.Inst().PushDialogue(ProgressDialogue()), lots of prog…

### DIFF
--- a/XSConsoleLayout.py
+++ b/XSConsoleLayout.py
@@ -83,6 +83,11 @@ class Layout:
     def TopDialogue(self):
         return self.dialogues[-1]
     
+    def PushDialogueEnhance(self, inDialogue):
+        while len(self.dialogues) > 1:
+            self.PopDialogue()
+        self.dialogues.append(inDialogue)
+ 
     def PushDialogue(self, inDialogue):
         self.dialogues.append(inDialogue)
         


### PR DESCRIPTION
…ress dialogue add up together. so we can't back to menu because just back to the last oneprogress dialogue, and this lead to a bad loop.